### PR TITLE
Merge tuples of transitively similar images in dictionary

### DIFF
--- a/CocoaImageHashing/OSSimilaritySearch.m
+++ b/CocoaImageHashing/OSSimilaritySearch.m
@@ -119,14 +119,22 @@
 - (NSDictionary<OSImageId *, NSSet<OSImageId *> *> *)dictionaryFromSimilarImagesResult:(NSArray<OSTuple<OSImageId *, OSImageId *> *> *)similarImageTuples
 {
     NSAssert(similarImageTuples, @"Similar image tuple array must not be nil");
-    NSMutableDictionary<OSImageId *, NSSet<OSImageId *> *> *result = [NSMutableDictionary new];
+    NSMutableDictionary<OSImageId *, OSImageId *> *representatives = [NSMutableDictionary new];
+    NSMutableDictionary<OSImageId *, NSMutableSet<OSImageId *> *> *result = [NSMutableDictionary new];
     for (OSTuple<OSImageId *, OSImageId *> *tuple in similarImageTuples) {
-        if (tuple.first && tuple.second) {
-            NSMutableSet<OSImageId *> *localMatches = (NSMutableSet<OSImageId *> *)result[OS_CAST_NONNULL(tuple.first)];
-            if (!localMatches) {
-                result[OS_CAST_NONNULL(tuple.first)] = localMatches = [NSMutableSet new];
+        OSImageId *first = tuple.first;
+        OSImageId *second = tuple.second;
+        if (first && second) {
+            OSImageId *firstRep = representatives[first];
+            if (!firstRep) {
+                representatives[first] = firstRep = first;
+                result[first] = [NSMutableSet set];
             }
-            [localMatches addObject:OS_CAST_NONNULL(tuple.second)];
+            OSImageId *secondRep = representatives[second];
+            if (!secondRep) {
+                representatives[second] = firstRep;
+            }
+            [result[firstRep] addObject:second];
         }
     }
     return result;

--- a/CocoaImageHashingTests/OSSimilaritySearchTests.m
+++ b/CocoaImageHashingTests/OSSimilaritySearchTests.m
@@ -31,4 +31,16 @@
     XCTAssertEqual([result count], expected, @"Invalid match count");
 }
 
+- (void)testDictionaryFromSimilarImagesResult
+{
+    NSArray<NSArray<OSDataHolder *> *> *dataSet = [self similarImages];
+    NSUInteger representativesCount = [dataSet count];
+    NSUInteger binSize = [[dataSet firstObject] count] - 1;
+    NSMutableArray<OSTuple<OSImageId *, OSImageId *> *> *similarTuples = [dataSet valueForKeyPath:@"@unionOfArrays.name.@arrayWithPairCombinations"];
+    NSDictionary<OSImageId *, NSSet<OSImageId *> *> *result = [[OSImageHashing sharedInstance] dictionaryFromSimilarImagesResult:similarTuples];
+    XCTAssertEqual([result count], representativesCount, @"There should be %lu different representatives", representativesCount);
+    XCTAssertEqualObjects([[result allValues] valueForKeyPath:@"@min.@count"], @(binSize), @"Representatives should not have less than %lu similar images", binSize);
+    XCTAssertEqualObjects([[result allValues] valueForKeyPath:@"@max.@count"], @(binSize), @"Representatives should not have more than %lu similar images", binSize);
+}
+
 @end


### PR DESCRIPTION
The current implementation of -[OSSimilaritySearch dictionaryFromSimilarImagesResult:] does not handle tuples of transitively similar images. Consider three images A, B, and C similar to each other. Similarity search will produce the tuples (A, B), (A, C), and (B, C), which are then transformed into the dictionary representation {A: [B, C], B: [C]}, whereas one would expect a representation like {A: [B, C]}.

To handle transitivity, this patch introduces a simplified union-find-like approach (another way being, for example, traversing connected components in a graph-like structure). The optimization is possible since the similarImages\* methods already return the list of tuples in a strictly ordered permutation, e. g. for the images above there cannot be a tuple (C, A).
