### PR TITLE
Scan line padding (take 2)

### DIFF
--- a/CocoaImageHashing/OSCategories.h
+++ b/CocoaImageHashing/OSCategories.h
@@ -63,8 +63,8 @@ NS_ASSUME_NONNULL_END
 NS_ASSUME_NONNULL_BEGIN
 
 + (NSBitmapImageRep *)imageRepFrom:(NSBitmapImageRep *)sourceImageRep
-                     scaledToWidth:(NSInteger)width
-                    scaledToHeight:(NSInteger)height
+                     scaledToWidth:(NSUInteger)width
+                    scaledToHeight:(NSUInteger)height
                 usingInterpolation:(NSImageInterpolation)imageInterpolation;
 
 NS_ASSUME_NONNULL_END

--- a/CocoaImageHashing/OSCategories.m
+++ b/CocoaImageHashing/OSCategories.m
@@ -52,6 +52,11 @@
 
 #pragma mark - NSData Category
 
+OS_INLINE OS_ALWAYS_INLINE NSUInteger OSBytesPerRowForWidth(NSUInteger width)
+{
+    return (width == 8) ? 32 : OS_ALIGN(4 * width, 64);
+}
+
 #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
 
 @implementation NSData (CocoaImageHashing)
@@ -68,8 +73,7 @@
         return nil;
     }
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    NSUInteger bytesPerPixel = 4;
-    NSUInteger bytesPerRow = OS_ALIGN(width * bytesPerPixel, 64);
+    NSUInteger bytesPerRow = OSBytesPerRowForWidth(width);
     NSUInteger bitsPerComponent = 8;
     NSMutableData *data = [NSMutableData dataWithLength:height * bytesPerRow];
     CGContextRef context = CGBitmapContextCreate([data mutableBytes], width, height, bitsPerComponent, bytesPerRow, colorSpace,
@@ -95,15 +99,15 @@
         return nil;
     }
     NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepFrom:sourceImageRep
-                                                  scaledToWidth:(NSInteger)width
-                                                 scaledToHeight:(NSInteger)height
+                                                  scaledToWidth:width
+                                                 scaledToHeight:height
                                              usingInterpolation:NSImageInterpolationHigh];
     if (!imageRep) {
         return nil;
     }
     unsigned char *pixels = [imageRep bitmapData];
     NSData *result = [NSData dataWithBytes:pixels
-                                    length:OS_ALIGN(4 * width, 64) * height];
+                                    length:OSBytesPerRowForWidth(width) * height];
     return result;
 }
 
@@ -118,19 +122,19 @@
 @implementation NSBitmapImageRep (CocoaImageHashing)
 
 + (NSBitmapImageRep *)imageRepFrom:(NSBitmapImageRep *)sourceImageRep
-                     scaledToWidth:(NSInteger)width
-                    scaledToHeight:(NSInteger)height
+                     scaledToWidth:(NSUInteger)width
+                    scaledToHeight:(NSUInteger)height
                 usingInterpolation:(NSImageInterpolation)imageInterpolation
 {
     NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:NULL
-                                                                         pixelsWide:width
-                                                                         pixelsHigh:height
+                                                                         pixelsWide:(NSInteger)width
+                                                                         pixelsHigh:(NSInteger)height
                                                                       bitsPerSample:8
                                                                     samplesPerPixel:4
                                                                            hasAlpha:YES
                                                                            isPlanar:NO
                                                                      colorSpaceName:NSCalibratedRGBColorSpace
-                                                                        bytesPerRow:OS_ALIGN(4 * width, 64) // multiple of 64 bytes to improve CG performance
+                                                                        bytesPerRow:(NSInteger)OSBytesPerRowForWidth(width)
                                                                        bitsPerPixel:0];
     [NSGraphicsContext saveGraphicsState];
     NSGraphicsContext *context = [NSGraphicsContext graphicsContextWithBitmapImageRep:imageRep];

--- a/CocoaImageHashing/OSCategories.m
+++ b/CocoaImageHashing/OSCategories.m
@@ -68,10 +68,10 @@
         return nil;
     }
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    NSMutableData *data = [NSMutableData dataWithLength:height * width * 4];
     NSUInteger bytesPerPixel = 4;
-    NSUInteger bytesPerRow = bytesPerPixel * width;
+    NSUInteger bytesPerRow = OS_ALIGN(width * bytesPerPixel, 64);
     NSUInteger bitsPerComponent = 8;
+    NSMutableData *data = [NSMutableData dataWithLength:height * bytesPerRow];
     CGContextRef context = CGBitmapContextCreate([data mutableBytes], width, height, bitsPerComponent, bytesPerRow, colorSpace,
                                                  kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Big);
     CGColorSpaceRelease(colorSpace);

--- a/CocoaImageHashingTests/OSFastGraphicsTests.m
+++ b/CocoaImageHashingTests/OSFastGraphicsTests.m
@@ -158,4 +158,22 @@
     NSLog(@"DCT processing %@ MB/s", @(MBs / executionTime));
 }
 
+- (void)testResizedRGBABitmapDataScanline
+{
+    NSData *imageData = [self loadImageAsData:@"misc/latrobe.bmp"];
+    for (NSUInteger dim = 8; dim <= 9; dim++) {
+        NSData *pixels = [imageData RGBABitmapDataForResizedImageWithWidth:dim
+                                                                 andHeight:dim];
+        uint64_t *lines = (uint64_t *)[pixels bytes];
+        NSUInteger length = [pixels length] / sizeof(lines);
+        for (NSUInteger i = 0; i < length; i += 8) {
+            XCTAssertNotEqual(lines[i], (uint64_t)0);
+            XCTAssertNotEqual(lines[i + 1], (uint64_t)0);
+            XCTAssertNotEqual(lines[i + 2], (uint64_t)0);
+            XCTAssertNotEqual(lines[i + 3], (uint64_t)0);
+            XCTAssertNotEqual(lines[i + 4], (uint64_t)0);
+        }
+    }
+}
+
 @end

--- a/CocoaImageHashingTests/OSFastGraphicsTests.m
+++ b/CocoaImageHashingTests/OSFastGraphicsTests.m
@@ -124,8 +124,8 @@
 - (void)testDCT
 {
     NSData *imageData = [self loadImageAsData:@"blurred/architecture1.bmp"];
-    NSData *pixels = [imageData RGBABitmapDataForResizedImageWithWidth:32
-                                                             andHeight:32];
+    NSData *pixels = [imageData RGBABitmapDataForResizedImageWithWidth:8
+                                                             andHeight:8];
     double greyscalePixels[32][32] = {{0.0}};
     double fastDctPixels[32][32] = {{0.0}};
     double dctPixels[32][32] = {{0.0}};
@@ -143,8 +143,8 @@
 {
     const NSUInteger iterations = 1024 * 2;
     NSData *imageData = [self loadImageAsData:@"blurred/architecture1.bmp"];
-    NSData *pixels = [imageData RGBABitmapDataForResizedImageWithWidth:32
-                                                             andHeight:32];
+    NSData *pixels = [imageData RGBABitmapDataForResizedImageWithWidth:8
+                                                             andHeight:8];
     double fastDctPixels[32][32] = {{0.0}};
     double greyscalePixels[32][32] = {{0.0}};
     greyscale_pixels_rgba_32_32([pixels bytes], greyscalePixels);


### PR DESCRIPTION
This PR addresses two problems introduced by 19f22bf:

- The dHash scan line size was fixed for macOS only.
- The use of OS_ALIGN results in a 64-byte scan line (and thus 32 bytes of zero padding) in images resized for aHash/pHash whereas their OSFastGraphics implementations expect contiguous scan lines of 32 bytes.

As a fix, an inline function, used by both macOS and iOS, is introduced that forces 32 bytes per row for aHash and pHash. Also, a basic test is added to detect obvious padding misconfigurations.