### PR TITLE
Fixed ignoring frequencies in pHash

### DIFF
--- a/CocoaImageHashing/OSFastGraphics.m
+++ b/CocoaImageHashing/OSFastGraphics.m
@@ -400,10 +400,10 @@ inline double fast_avg_no_first_el_rgba_8_8(const double pixels[32][32])
 
 #pragma mark - pHash
 
-#define INLINE_PHASH(row, col)                                   \
-    if (row != 0 && col != 0 && pixels[row][col] > dctAverage) { \
-        SETBIT(result, cnt);                                     \
-    }                                                            \
+#define INLINE_PHASH(row, col)                                     \
+    if ((row != 0 || col != 0) && pixels[row][col] > dctAverage) { \
+        SETBIT(result, cnt);                                       \
+    }                                                              \
     cnt++;
 
 #define UNROLL_PHASH_Y(row) \

--- a/CocoaImageHashingTests/OSAHashTests.m
+++ b/CocoaImageHashingTests/OSAHashTests.m
@@ -35,4 +35,17 @@
     XCTAssertEqual(OSHashTypeError, result);
 }
 
+- (void)testAHashValuesRegression
+{
+    [self assertHashOfImageWithName:@"blurred/architecture1.bmp"
+                          isEqualTo:-8608191228601917537
+                        forProvider:OSImageHashingProviderAHash];
+    [self assertHashOfImageWithName:@"compressed/architecture1.jpg"
+                          isEqualTo:-8608472703578630209
+                        forProvider:OSImageHashingProviderAHash];
+    [self assertHashOfImageWithName:@"blurred/bamarket115.bmp"
+                          isEqualTo:-16954737706286081
+                        forProvider:OSImageHashingProviderAHash];
+}
+
 @end

--- a/CocoaImageHashingTests/OSDHashTests.m
+++ b/CocoaImageHashingTests/OSDHashTests.m
@@ -118,4 +118,17 @@
     XCTAssertEqual(OSHashTypeError, result);
 }
 
+- (void)testDHashValuesRegression
+{
+    [self assertHashOfImageWithName:@"blurred/architecture1.bmp"
+                          isEqualTo:8878387448951351155
+                        forProvider:OSImageHashingProviderDHash];
+    [self assertHashOfImageWithName:@"compressed/architecture1.jpg"
+                          isEqualTo:8878387448951351155
+                        forProvider:OSImageHashingProviderDHash];
+    [self assertHashOfImageWithName:@"blurred/bamarket115.bmp"
+                          isEqualTo:434042140785579798
+                        forProvider:OSImageHashingProviderDHash];
+}
+
 @end

--- a/CocoaImageHashingTests/OSImageHashingBaseTest.h
+++ b/CocoaImageHashingTests/OSImageHashingBaseTest.h
@@ -47,5 +47,8 @@
         withImageHashingProviderId:(OSImageHashingProviderId)imageHashingProviderId;
 - (void)assertImageSimilarityForProvider:(OSImageHashingProviderId)imageHashingProvider
                               forDataSet:(NSArray<NSArray<OSDataHolder *> *> *)dataSet;
+- (void)assertHashOfImageWithName:(NSString *)imageName
+                        isEqualTo:(OSHashType)referenceHash
+                      forProvider:(OSImageHashingProviderId)imageHashingProvider;
 
 @end

--- a/CocoaImageHashingTests/OSImageHashingBaseTest.m
+++ b/CocoaImageHashingTests/OSImageHashingBaseTest.m
@@ -264,4 +264,16 @@
     }
 }
 
+// Hashes should never change for same images. Users of this library are relying on the values.
+- (void)assertHashOfImageWithName:(NSString *)imageName
+                        isEqualTo:(OSHashType)referenceHash
+                      forProvider:(OSImageHashingProviderId)imageHashingProvider
+{
+    NSData *imageData = [self loadImageAsData:imageName];
+    OSHashType actualHash = [[OSImageHashing sharedInstance] hashImageData:imageData
+                                                            withProviderId:imageHashingProvider];
+    
+    XCTAssertEqual(actualHash, referenceHash, @"Actual hash do not match reference hash");
+}
+
 @end

--- a/CocoaImageHashingTests/OSPHashTests.m
+++ b/CocoaImageHashingTests/OSPHashTests.m
@@ -93,4 +93,17 @@
     XCTAssertEqual(OSHashTypeError, result);
 }
 
+- (void)testPHashValuesRegression
+{
+    [self assertHashOfImageWithName:@"blurred/architecture1.bmp"
+                          isEqualTo:7064092248754547030
+                        forProvider:OSImageHashingProviderPHash];
+    [self assertHashOfImageWithName:@"compressed/architecture1.jpg"
+                          isEqualTo:7064092248754530646
+                        forProvider:OSImageHashingProviderPHash];
+    [self assertHashOfImageWithName:@"blurred/bamarket115.bmp"
+                          isEqualTo:635247255876156
+                        forProvider:OSImageHashingProviderPHash];
+}
+
 @end


### PR DESCRIPTION
15 of lowest 64 frequencies were ignored instead of suggested 1. This caused images with low details produce 0 hash (e.g.: screenshots of UI).

Note that this breaks compatibility with previously generated values of pHash. I've added tests that check future possible regression of values.

My reference to the algorithm was: http://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html#c1410