### PR TITLE
Fix "Include of non-modular header inside of framework module" by changing to local imports

### DIFF
--- a/CocoaImageHashing/CocoaImageHashing.h
+++ b/CocoaImageHashing/CocoaImageHashing.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Andreas Meingast. All rights reserved.
 //
 
-#import <CocoaImageHashing/OSImageHashing.h>
+#import "OSImageHashing.h"
 
 FOUNDATION_EXPORT double CocoaImageHashingVersionNumber;
 FOUNDATION_EXPORT const unsigned char CocoaImageHashingVersionString[];

--- a/CocoaImageHashing/OSImageHashing.h
+++ b/CocoaImageHashing/OSImageHashing.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Andreas Meingast. All rights reserved.
 //
 
-#import <CocoaImageHashing/OSTypes.h>
+#import "OSTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
I'm hitting 2 `Include of non-modular header inside of framework module` build errors when consuming CocoaImageHashing through CocoaPods in a simple Swift project.

1st error:
![Screen Shot 2019-03-14 at 13 24 01](https://user-images.githubusercontent.com/1527302/54332177-6235ab80-4660-11e9-8ad0-5d1363296a35.png)

Podfile contents:
```
target 'Tidy iOS' do
  use_frameworks!

  pod 'CocoaImageHashing'
end
```
Swift file contents:
```
import CocoaImageHashing
```

The root cause seems to be that the includes aren't resolving correctly.

Testing performed:
- Ran CocoaImageHashing's XCUnit tests
- Pointed my simple Swift project's Podfile to the fixed commit, ran `rm -rf Pods && pod install`, and built successfully.
