### PR TITLE
Fix nullability annotations in OSImageHashing

### DIFF
--- a/CocoaImageHashing/OSImageHashing.h
+++ b/CocoaImageHashing/OSImageHashing.h
@@ -101,27 +101,27 @@ NS_ASSUME_NONNULL_BEGIN
  * Such an ID can for example be the unique file-path of an image on disk or a database-id referencing an image.
  */
 - (NSArray<OSTuple<OSImageId *, OSImageId *> *> *)similarImagesWithHashingQuality:(OSImageHashingQuality)imageHashingQuality
-                                                            forImageStreamHandler:(OSTuple<OSImageId *, NSData *> * (^)(void))imageStreamHandler;
+                                                            forImageStreamHandler:(OSTuple<OSImageId *, NSData *> *__nullable (^)(void))imageStreamHandler;
 
 /**
  * @see -[OSImageHashing similarImagesWithHashingQuality::]
  */
 - (NSArray<OSTuple<OSImageId *, OSImageId *> *> *)similarImagesWithHashingQuality:(OSImageHashingQuality)imageHashingQuality
                                                         withHashDistanceThreshold:(OSHashDistanceType)hashDistanceThreshold
-                                                            forImageStreamHandler:(OSTuple<OSImageId *, NSData *> * (^)(void))imageStreamHandler;
+                                                            forImageStreamHandler:(OSTuple<OSImageId *, NSData *> *__nullable (^)(void))imageStreamHandler;
 
 /**
  * @see -[OSImageHashing similarImagesWithHashingQuality::]
  */
 - (NSArray<OSTuple<OSImageId *, OSImageId *> *> *)similarImagesWithProvider:(OSImageHashingProviderId)imageHashingProviderId
-                                                      forImageStreamHandler:(OSTuple<OSImageId *, NSData *> * (^)(void))imageStreamHandler;
+                                                      forImageStreamHandler:(OSTuple<OSImageId *, NSData *> *__nullable (^)(void))imageStreamHandler;
 
 /**
  * @see -[OSImageHashing similarImagesWithHashingQuality::]
  */
 - (NSArray<OSTuple<OSImageId *, OSImageId *> *> *)similarImagesWithProvider:(OSImageHashingProviderId)imageHashingProviderId
                                                   withHashDistanceThreshold:(OSHashDistanceType)hashDistanceThreshold
-                                                      forImageStreamHandler:(OSTuple<OSImageId *, NSData *> * (^)(void))imageStreamHandler;
+                                                      forImageStreamHandler:(OSTuple<OSImageId *, NSData *> *__nullable (^)(void))imageStreamHandler;
 
 #pragma mark - Concurrent, array based similarity search
 


### PR DESCRIPTION
- The stream based methods say this in their docs: 

```
 * Data is provided through the imageStreamHandler parameter. Returning nil inside imageStreamHandler
 * signals that the stream was closed and no more data is available.
```

However, since the entire class is marked as `NS_ASSUME_NONNULL`, it's not possible to return `nil` from swift in these stream based methods.

This PR fixes the annotations, allowing a `nil` return from the closure in swift.